### PR TITLE
PIP-1104-add-cat-get-int-from-file

### DIFF
--- a/tests/data/dnase/normalizing/nuclear.count
+++ b/tests/data/dnase/normalizing/nuclear.count
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdf779cf38b5075da8af97f4aa9da6593fa9add4fe3b0b81617b492f3238c39d
+size 7

--- a/tests/integration/test_samtools.yml
+++ b/tests/integration/test_samtools.yml
@@ -168,6 +168,7 @@
     contains:
       - "samtools view"
       - "-c"
+      - "cat"
       - "174806"
 
 - name: test_get_stats_and_flagstats_from_bam

--- a/tests/unit/json/test_cat_get_int_from_file.json
+++ b/tests/unit/json/test_cat_get_int_from_file.json
@@ -1,0 +1,8 @@
+{
+    "test_cat_get_int_from_file.in": "tests/data/dnase/normalizing/nuclear.count",
+    "test_cat_get_int_from_file.resources": {
+        "cpu": 1,
+        "memory_gb": 2,
+        "disks": "local-disk 10 SSD"
+    }
+}

--- a/tests/unit/test_cat.yml
+++ b/tests/unit/test_cat.yml
@@ -10,3 +10,15 @@
       - "cat"
       - "dummy.txt"
       - "> concatenated"
+
+- name: test_cat_get_int_from_file
+  tags:
+    - unit
+  command: >-
+    tests/caper_run.sh \
+    tests/unit//wdl/test_cat_get_int_from_file.wdl \
+    tests/unit/json/test_cat_get_int_from_file.json
+  stdout:
+    contains:
+      - "cat"
+      - "174806"

--- a/tests/unit/wdl/test_cat_get_int_from_file.wdl
+++ b/tests/unit/wdl/test_cat_get_int_from_file.wdl
@@ -1,0 +1,18 @@
+version 1.0
+
+
+import "../../../wdl/tasks/cat.wdl"
+
+
+workflow test_cat_get_int_from_file {
+    input {
+        File in
+        Resources resources
+    }
+
+    call cat.get_int_from_file {
+        input:
+            in=in,
+            resources=resources,
+    }
+}

--- a/wdl/subworkflows/get_number_of_reads_from_bam.wdl
+++ b/wdl/subworkflows/get_number_of_reads_from_bam.wdl
@@ -1,6 +1,7 @@
 version 1.0
 
 
+import "../tasks/cat.wdl"
 import "../tasks/samtools.wdl"
 
 
@@ -20,7 +21,13 @@ workflow get_number_of_reads_from_bam {
             resources=resources,
     }
 
+    call cat.get_int_from_file {
+        input:
+            in=view.out,
+            resources=resources,
+    }
+
     output {
-        Int count = read_int(view.out)
+        Int count = get_int_from_file.out
     }
 }

--- a/wdl/tasks/cat.wdl
+++ b/wdl/tasks/cat.wdl
@@ -27,3 +27,26 @@ task cat {
         disks: resources.disks
     }
 }
+
+
+task get_int_from_file {
+    input {
+        File in
+        Resources resources
+    }
+
+    command {
+        cat \
+            ~{in}
+    }
+
+    output {
+        Int out = read_int(stdout())
+    }
+
+    runtime {
+        cpu: resources.cpu
+        memory: "~{resources.memory_gb} GB"
+        disks: resources.disks
+    }
+}


### PR DESCRIPTION
This is a workaround to Cromwell's `read_int` which doesn't work on Google Cloud files.